### PR TITLE
Fix MediaTranscoding

### DIFF
--- a/Model/MediaObj.cs
+++ b/Model/MediaObj.cs
@@ -154,7 +154,7 @@ namespace hitaBot.Refit.Model
         ///     Gets or Sets MediaTranscoding
         /// </summary>
         [DataMember(Name = "media_transcoding", EmitDefaultValue = false)]
-        public int MediaTranscoding { get; set; }
+        public int? MediaTranscoding { get; set; }
 
         /// <summary>
         ///     Gets or Sets MediaRepairSource


### PR DESCRIPTION
JSON parsing error on  
GET /media/live/list  

```
Error converting value {null} to type 'System.Int32'. Path 'livestream[7].media_transcoding', line 1, position 13795.
```
